### PR TITLE
refactor: common-layout, base-layout をモックするように変更

### DIFF
--- a/frontend/octavio/__test__/pages/index.test.tsx
+++ b/frontend/octavio/__test__/pages/index.test.tsx
@@ -18,8 +18,16 @@ vi.mock("@/components/MarkdownPreview", () => ({
 }));
 vi.mock("@/layouts/CommonLayout", () => ({
   __esModule: true,
-  default: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="common-layout">{children}</div>
+  default: ({
+    children,
+    title,
+  }: {
+    children: React.ReactNode;
+    title: string;
+  }) => (
+    <div data-testid="common-layout" data-title={title}>
+      {children}
+    </div>
   ),
 }));
 
@@ -35,6 +43,10 @@ describe("Home", () => {
 
     // verify
     expect(screen.queryByTestId("common-layout")).toBeInTheDocument();
+    expect(screen.queryByTestId("common-layout")).toHaveAttribute(
+      "data-title",
+      "ルール"
+    );
     expect(screen.queryByTestId("markdown-preview")).toBeInTheDocument();
     expect(screen.queryByTestId("markdown-preview")).toHaveAttribute(
       "data-content",

--- a/frontend/octavio/__test__/pages/login.test.tsx
+++ b/frontend/octavio/__test__/pages/login.test.tsx
@@ -1,5 +1,7 @@
 import "@testing-library/jest-dom";
 
+import React from "react";
+
 import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import mockRouter from "next-router-mock";
@@ -37,6 +39,20 @@ vi.mock("@/components/Alerts", () => ({
     />
   ),
 }));
+vi.mock("@/layouts/CommonLayout", () => ({
+  __esModule: true,
+  default: ({
+    children,
+    title,
+  }: {
+    children: React.ReactNode;
+    title: string;
+  }) => (
+    <div data-testid="common-layout" data-title={title}>
+      {children}
+    </div>
+  ),
+}));
 
 beforeEach(() => {
   // toHaveBeenCalledTimes がテストごとにリセットされるようにする
@@ -55,11 +71,19 @@ describe("Login", () => {
 
     const loginButton = screen.getByRole("button");
 
-    // verify
+    // then
+    expect(screen.queryByTestId("common-layout")).toBeInTheDocument();
+    expect(screen.queryByTestId("common-layout")).toHaveAttribute(
+      "data-title",
+      "ログイン"
+    );
     expect(screen.queryByPlaceholderText("ユーザー名")).toBeInTheDocument();
     expect(screen.queryByPlaceholderText("パスワード")).toBeInTheDocument();
     expect(loginButton).toBeInTheDocument();
     expect(loginButton).not.toHaveAttribute("loading");
+
+    // verify
+    expect(useAuth).toHaveBeenCalledTimes(1);
   });
 
   test("未入力で送信した時にエラーメッセージが表示されることを確認する", async () => {
@@ -81,6 +105,9 @@ describe("Login", () => {
     expect(
       screen.queryByText("パスワードを入力して下さい")
     ).toBeInTheDocument();
+
+    // verify
+    expect(useAuth).toHaveBeenCalledTimes(2);
   });
 
   test("ユーザー名が未入力で送信した時にエラーメッセージが表示されることを確認する", async () => {
@@ -127,6 +154,9 @@ describe("Login", () => {
     expect(
       screen.queryByText("パスワードを入力して下さい")
     ).toBeInTheDocument();
+
+    // verify
+    expect(useAuth).toHaveBeenCalledTimes(2);
   });
 
   test("ログインが成功することを確認する", async () => {
@@ -158,7 +188,7 @@ describe("Login", () => {
     expect(alert).not.toHaveAttribute("data-sub-message");
 
     // verify
-    expect(useAuth).toHaveBeenCalledTimes(4);
+    expect(useAuth).toHaveBeenCalledTimes(2);
     expect(signIn).toHaveBeenCalledTimes(1);
   });
 
@@ -188,7 +218,7 @@ describe("Login", () => {
     expect(alert).not.toHaveAttribute("data-sub-message");
 
     // verify
-    expect(useAuth).toHaveBeenCalledTimes(4);
+    expect(useAuth).toHaveBeenCalledTimes(2);
     expect(signIn).toHaveBeenCalledTimes(1);
   });
 
@@ -223,7 +253,7 @@ describe("Login", () => {
     expect(loginButton).toHaveClass("loading");
 
     // verify
-    expect(useAuth).toHaveBeenCalledTimes(4);
+    expect(useAuth).toHaveBeenCalledTimes(2);
     expect(signIn).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/octavio/__test__/pages/notices.test.tsx
+++ b/frontend/octavio/__test__/pages/notices.test.tsx
@@ -1,5 +1,7 @@
 import "@testing-library/jest-dom";
 
+import React from "react";
+
 import { render, screen } from "@testing-library/react";
 import { Mock, vi } from "vitest";
 
@@ -8,13 +10,23 @@ import Notices from "@/pages/notices";
 import { testNotice } from "@/types/Notice";
 
 vi.mock("@/hooks/notice");
-vi.mock("@/components/Navbar", () => ({
-  __esModule: true,
-  default: () => <div data-testid="navbar" />,
-}));
 vi.mock("@/components/NotificationCard", () => ({
   __esModule: true,
   default: () => <div data-testid="notification-card" />,
+}));
+vi.mock("@/layouts/CommonLayout", () => ({
+  __esModule: true,
+  default: ({
+    children,
+    title,
+  }: {
+    children: React.ReactNode;
+    title: string;
+  }) => (
+    <div data-testid="common-layout" data-title={title}>
+      {children}
+    </div>
+  ),
 }));
 
 beforeEach(() => {
@@ -34,7 +46,11 @@ describe("Notices", () => {
     render(<Notices />);
 
     // then
-    expect(screen.getByTestId("navbar")).toBeInTheDocument();
+    expect(screen.getByTestId("common-layout")).toBeInTheDocument();
+    expect(screen.getByTestId("common-layout")).toHaveAttribute(
+      "data-title",
+      "通知一覧"
+    );
     expect(screen.getByTestId("notification-card")).toBeInTheDocument();
 
     // verify
@@ -52,7 +68,7 @@ describe("Notices", () => {
     render(<Notices />);
 
     // then
-    expect(screen.getByTestId("navbar")).toBeInTheDocument();
+    expect(screen.getByTestId("common-layout")).toBeInTheDocument();
     expect(screen.queryByTestId("notification-card")).not.toBeInTheDocument();
 
     // verify

--- a/frontend/octavio/__test__/pages/problems/[problemId].test.tsx
+++ b/frontend/octavio/__test__/pages/problems/[problemId].test.tsx
@@ -39,10 +39,6 @@ vi.mock("next/router", () => ({
 vi.mock("@/hooks/auth");
 vi.mock("@/hooks/problem");
 vi.mock("@/hooks/reCreateInfo");
-vi.mock("@/components/Navbar", () => ({
-  __esModule: true,
-  default: () => <div data-testid="navbar" />,
-}));
 vi.mock("@/components/AnswerForm", () => ({
   __esModule: true,
   default: () => <div data-testid="answerForm" />,
@@ -50,6 +46,20 @@ vi.mock("@/components/AnswerForm", () => ({
 vi.mock("@/components/AnswerListSection", () => ({
   __esModule: true,
   default: () => <div data-testid="answerListSection" />,
+}));
+vi.mock("@/layouts/BaseLayout", () => ({
+  __esModule: true,
+  default: ({
+    children,
+    title,
+  }: {
+    children: React.ReactNode;
+    title: string;
+  }) => (
+    <div data-testid="base-layout" data-title={title}>
+      {children}
+    </div>
+  ),
 }));
 
 beforeEach(() => {
@@ -73,8 +83,14 @@ describe("[problemId]", () => {
     });
     render(<ProblemPage />);
 
+    screen.debug();
+
     // then
-    expect(screen.queryByTestId("navbar")).toBeInTheDocument();
+    expect(screen.queryByTestId("base-layout")).toBeInTheDocument();
+    expect(screen.queryByTestId("base-layout")).toHaveAttribute(
+      "data-title",
+      `${testProblem.code} ${testProblem.title} 問題`
+    );
     expect(
       screen.queryByRole("button", { name: "再展開を行う" })
     ).not.toBeInTheDocument();
@@ -100,6 +116,11 @@ describe("[problemId]", () => {
     render(<ProblemPage />);
 
     // then
+    expect(screen.queryByTestId("base-layout")).toBeInTheDocument();
+    expect(screen.queryByTestId("base-layout")).toHaveAttribute(
+      "data-title",
+      "Loading..."
+    );
     expect(screen.queryByTestId("loading")).toBeInTheDocument();
 
     // verify
@@ -247,7 +268,7 @@ describe("[problemId]", () => {
     render(<ProblemPage />);
 
     // then
-    expect(screen.queryByTestId("navbar")).toBeInTheDocument();
+    expect(screen.queryByTestId("base-layout")).toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: "再展開を行う" })
     ).toBeInTheDocument();
@@ -276,7 +297,7 @@ describe("[problemId]", () => {
     render(<ProblemPage />);
 
     // then
-    expect(screen.queryByTestId("navbar")).toBeInTheDocument();
+    expect(screen.queryByTestId("base-layout")).toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: "再展開を行う" })
     ).not.toBeInTheDocument();

--- a/frontend/octavio/__test__/pages/problems/index.test.tsx
+++ b/frontend/octavio/__test__/pages/problems/index.test.tsx
@@ -1,10 +1,11 @@
 import "@testing-library/jest-dom";
 
+import React from "react";
+
 import { render, screen } from "@testing-library/react";
 import { useRecoilState } from "recoil";
 import { Mock, vi } from "vitest";
 
-import useAuth from "@/hooks/auth";
 import useNotice from "@/hooks/notice";
 import useProblems from "@/hooks/problems";
 import Problems from "@/pages/problems";
@@ -12,10 +13,23 @@ import { testNotice } from "@/types/Notice";
 import { testProblem } from "@/types/Problem";
 
 vi.mock("recoil");
-vi.mock("@/hooks/auth");
 vi.mock("@/hooks/problems");
 vi.mock("@/hooks/notice");
 vi.mock("next/router", () => require("next-router-mock"));
+vi.mock("@/layouts/CommonLayout", () => ({
+  __esModule: true,
+  default: ({
+    children,
+    title,
+  }: {
+    children: React.ReactNode;
+    title: string;
+  }) => (
+    <div data-testid="common-layout" data-title={title}>
+      {children}
+    </div>
+  ),
+}));
 
 beforeEach(() => {
   // toHaveBeenCalledTimes がテストごとにリセットされるようにする
@@ -26,9 +40,6 @@ describe("Problems", () => {
   test("画面が表示されることを確認する", async () => {
     // setup
     (useRecoilState as Mock).mockReturnValue([[], vi.fn()]);
-    (useAuth as Mock).mockReturnValue({
-      user: null,
-    });
     (useProblems as Mock).mockReturnValue({
       problems: [testProblem],
       isLoading: false,
@@ -37,9 +48,15 @@ describe("Problems", () => {
       notices: [testNotice],
       isLoading: false,
     });
+
     render(<Problems />);
 
     // verify
+    expect(screen.getByTestId("common-layout")).toBeInTheDocument();
+    expect(screen.getByTestId("common-layout")).toHaveAttribute(
+      "data-title",
+      "問題一覧"
+    );
     expect(screen.queryByText("テスト通知タイトル")).toBeInTheDocument();
     expect(screen.queryByText("テスト通知本文")).toBeInTheDocument();
     expect(screen.queryByText("XYZ")).toBeInTheDocument();
@@ -52,9 +69,6 @@ describe("Problems", () => {
   test("問題一覧とお知らせ一覧が取得中の場合、ローディング画面が表示されることを確認する", async () => {
     // setup
     (useRecoilState as Mock).mockReturnValue([[], vi.fn()]);
-    (useAuth as Mock).mockReturnValue({
-      user: null,
-    });
     (useProblems as Mock).mockReturnValue({
       problems: [],
       isLoading: true,
@@ -65,8 +79,11 @@ describe("Problems", () => {
     });
     render(<Problems />);
 
-    // verify
+    // then
+    expect(screen.getByTestId("common-layout")).toBeInTheDocument();
     expect(screen.queryByTestId("loading")).toBeInTheDocument();
+
+    // verify
     expect(useProblems).toHaveBeenCalledTimes(1);
     expect(useNotice).toHaveBeenCalledTimes(1);
   });
@@ -74,9 +91,6 @@ describe("Problems", () => {
   test("問題一覧が取得中の場合、ローディング画面が表示されることを確認する", async () => {
     // setup
     (useRecoilState as Mock).mockReturnValue([[], vi.fn()]);
-    (useAuth as Mock).mockReturnValue({
-      user: null,
-    });
     (useProblems as Mock).mockReturnValue({
       problems: [],
       isLoading: true,
@@ -87,8 +101,11 @@ describe("Problems", () => {
     });
     render(<Problems />);
 
-    // verify
+    // then
+    expect(screen.getByTestId("common-layout")).toBeInTheDocument();
     expect(screen.queryByTestId("loading")).toBeInTheDocument();
+
+    // verify
     expect(useProblems).toHaveBeenCalledTimes(1);
     expect(useNotice).toHaveBeenCalledTimes(1);
   });
@@ -96,9 +113,6 @@ describe("Problems", () => {
   test("お知らせ一覧が取得中の場合、ローディング画面が表示されることを確認する", async () => {
     // setup
     (useRecoilState as Mock).mockReturnValue([[], vi.fn()]);
-    (useAuth as Mock).mockReturnValue({
-      user: null,
-    });
     (useProblems as Mock).mockReturnValue({
       problems: [],
       isLoading: false,
@@ -109,8 +123,11 @@ describe("Problems", () => {
     });
     render(<Problems />);
 
-    // verify
+    // then
+    expect(screen.getByTestId("common-layout")).toBeInTheDocument();
     expect(screen.queryByTestId("loading")).toBeInTheDocument();
+
+    // verify
     expect(useProblems).toHaveBeenCalledTimes(1);
     expect(useNotice).toHaveBeenCalledTimes(1);
   });
@@ -118,9 +135,6 @@ describe("Problems", () => {
   test("見えなくされている場合、お知らせが表示されないことを確認する", async () => {
     // setup
     (useRecoilState as Mock).mockReturnValue([[testNotice.source_id], vi.fn()]);
-    (useAuth as Mock).mockReturnValue({
-      user: null,
-    });
     (useProblems as Mock).mockReturnValue({
       problems: [testProblem],
       isLoading: false,
@@ -131,9 +145,12 @@ describe("Problems", () => {
     });
     render(<Problems />);
 
-    // verify
+    // then
+    expect(screen.getByTestId("common-layout")).toBeInTheDocument();
     expect(screen.queryByText("テスト通知タイトル")).not.toBeInTheDocument();
     expect(screen.queryByText("テスト通知本文")).not.toBeInTheDocument();
+
+    // verify
     expect(useProblems).toHaveBeenCalledTimes(1);
     expect(useNotice).toHaveBeenCalledTimes(1);
   });
@@ -142,9 +159,6 @@ describe("Problems", () => {
     // setup
     const onDismiss = vi.fn();
     (useRecoilState as Mock).mockReturnValue([[], onDismiss]);
-    (useAuth as Mock).mockReturnValue({
-      user: null,
-    });
     (useProblems as Mock).mockReturnValue({
       problems: [testProblem],
       isLoading: false,
@@ -159,6 +173,7 @@ describe("Problems", () => {
     screen.getByRole("button").click();
 
     // then
+    expect(screen.getByTestId("common-layout")).toBeInTheDocument();
     expect(onDismiss).toHaveBeenCalledWith([testNotice.source_id]);
 
     // verify
@@ -171,9 +186,6 @@ describe("Problems", () => {
     // setup
     const onDismiss = vi.fn();
     (useRecoilState as Mock).mockReturnValue([["TEST"], onDismiss]);
-    (useAuth as Mock).mockReturnValue({
-      user: null,
-    });
     (useProblems as Mock).mockReturnValue({
       problems: [testProblem],
       isLoading: false,
@@ -188,6 +200,7 @@ describe("Problems", () => {
     screen.getByRole("button").click();
 
     // then
+    expect(screen.getByTestId("common-layout")).toBeInTheDocument();
     expect(onDismiss).toHaveBeenCalledWith(["TEST", testNotice.source_id]);
 
     // verify
@@ -204,9 +217,6 @@ describe("Problems", () => {
       shortRule: "# ルール本文",
     }));
     (useRecoilState as Mock).mockReturnValue([[], vi.fn()]);
-    (useAuth as Mock).mockReturnValue({
-      user: null,
-    });
     (useProblems as Mock).mockReturnValue({
       problems: [testProblem],
       isLoading: false,
@@ -217,8 +227,11 @@ describe("Problems", () => {
     });
     render(<Problems />);
 
-    // verify
+    // then
+    expect(screen.getByTestId("common-layout")).toBeInTheDocument();
     expect(screen.queryByText("ルール本文")).toBeInTheDocument();
+
+    // verify
     expect(useProblems).toHaveBeenCalledTimes(1);
     expect(useNotice).toHaveBeenCalledTimes(1);
   });

--- a/frontend/octavio/__test__/pages/profile.test.tsx
+++ b/frontend/octavio/__test__/pages/profile.test.tsx
@@ -1,5 +1,7 @@
 import "@testing-library/jest-dom";
 
+import React from "react";
+
 import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Mock, vi } from "vitest";
@@ -15,10 +17,6 @@ vi.mock("next/error", () => ({
   ),
 }));
 vi.mock("@/hooks/auth");
-vi.mock("@/components/Navbar", () => ({
-  __esModule: true,
-  default: () => <div data-testid="navbar" />,
-}));
 vi.mock("@/components/Alerts", () => ({
   ICTSCSuccessAlert: ({
     message,
@@ -51,6 +49,20 @@ vi.mock("@/components/LoadingPage", () => ({
   __esModule: true,
   default: () => <div data-testid="loading" />,
 }));
+vi.mock("@/layouts/CommonLayout", () => ({
+  __esModule: true,
+  default: ({
+    children,
+    title,
+  }: {
+    children: React.ReactNode;
+    title: string;
+  }) => (
+    <div data-testid="common-layout" data-title={title}>
+      {children}
+    </div>
+  ),
+}));
 
 beforeEach(() => {
   // toHaveBeenCalledTimes がテストごとにリセットされるようにする
@@ -69,7 +81,11 @@ describe("Profile", () => {
     render(<Profile />);
 
     // then
-    expect(screen.getByTestId("navbar")).toBeInTheDocument();
+    expect(screen.getByTestId("common-layout")).toBeInTheDocument();
+    expect(screen.getByTestId("common-layout")).toHaveAttribute(
+      "data-title",
+      "プロフィール"
+    );
     expect(screen.getByText(testUser.user_group.name)).toBeInTheDocument();
     const inputs = screen.getAllByRole("textbox");
     expect(inputs).toHaveLength(5);
@@ -78,6 +94,9 @@ describe("Profile", () => {
     expect(inputs[2]).toHaveValue(testUser.profile?.github_id);
     expect(inputs[3]).toHaveValue(testUser.profile?.twitter_id);
     expect(inputs[4]).toHaveValue(testUser.profile?.facebook_id);
+
+    // verify
+    expect(useAuth).toHaveBeenCalledTimes(2);
   });
 
   test("ユーザーが取得中の場合、ローディング画面が表示されることを確認する", async () => {
@@ -91,7 +110,7 @@ describe("Profile", () => {
     render(<Profile />);
 
     // then
-    expect(screen.getByTestId("navbar")).toBeInTheDocument();
+    expect(screen.getByTestId("common-layout")).toBeInTheDocument();
     expect(screen.getByTestId("loading")).toBeInTheDocument();
 
     // verify
@@ -109,7 +128,7 @@ describe("Profile", () => {
     render(<Profile />);
 
     // then
-    expect(screen.queryByTestId("navbar")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("common-layout")).not.toBeInTheDocument();
     expect(screen.getByTestId("error")).toBeInTheDocument();
     expect(screen.getByTestId("error")).toHaveAttribute(
       "data-status-code",

--- a/frontend/octavio/__test__/pages/ranking.test.tsx
+++ b/frontend/octavio/__test__/pages/ranking.test.tsx
@@ -1,5 +1,7 @@
 import "@testing-library/jest-dom";
 
+import React from "react";
+
 import { render, screen } from "@testing-library/react";
 import { Mock, vi } from "vitest";
 
@@ -8,13 +10,23 @@ import Ranking from "@/pages/ranking";
 import { testRank } from "@/types/Rank";
 
 vi.mock("@/hooks/ranking");
-vi.mock("@/components/Navbar", () => ({
-  __esModule: true,
-  default: () => <div data-testid="navbar" />,
-}));
 vi.mock("@/components/LoadingPage", () => ({
   __esModule: true,
   default: () => <div data-testid="loading" />,
+}));
+vi.mock("@/layouts/CommonLayout", () => ({
+  __esModule: true,
+  default: ({
+    children,
+    title,
+  }: {
+    children: React.ReactNode;
+    title: string;
+  }) => (
+    <div data-testid="common-layout" data-title={title}>
+      {children}
+    </div>
+  ),
 }));
 
 beforeEach(() => {
@@ -34,7 +46,11 @@ describe("Ranking", () => {
     render(<Ranking />);
 
     // then
-    expect(screen.getByTestId("navbar")).toBeInTheDocument();
+    expect(screen.getByTestId("common-layout")).toBeInTheDocument();
+    expect(screen.getByTestId("common-layout")).toHaveAttribute(
+      "data-title",
+      "ランキング"
+    );
     const cells = screen.getAllByRole("cell");
     expect(cells[0]).toHaveTextContent(testRank.rank.toString());
     expect(cells[1]).toHaveTextContent(testRank.user_group.name);
@@ -56,7 +72,7 @@ describe("Ranking", () => {
     render(<Ranking />);
 
     // then
-    expect(screen.getByTestId("navbar")).toBeInTheDocument();
+    expect(screen.getByTestId("common-layout")).toBeInTheDocument();
     expect(screen.getByTestId("loading")).toBeInTheDocument();
 
     // verify

--- a/frontend/octavio/__test__/pages/scoring/[code].test.tsx
+++ b/frontend/octavio/__test__/pages/scoring/[code].test.tsx
@@ -1,5 +1,7 @@
 import "@testing-library/jest-dom";
 
+import React from "react";
+
 import { render, screen } from "@testing-library/react";
 import mockRouter from "next-router-mock";
 import { useForm } from "react-hook-form";
@@ -26,10 +28,6 @@ vi.mock("react-hook-form", () => ({
 vi.mock("@/hooks/auth");
 vi.mock("@/hooks/problem");
 vi.mock("@/hooks/answer");
-vi.mock("@/components/Navbar", () => ({
-  __esModule: true,
-  default: () => <div data-testid="navbar" />,
-}));
 vi.mock("@/components/LoadingPage", () => ({
   __esModule: true,
   default: () => <div data-testid="loading" />,
@@ -38,6 +36,20 @@ vi.mock("@/components/ScoringAnswerForm", () => ({
   __esModule: true,
   default: ({ answer }: { answer: Answer }) => (
     <div data-testid="scoring-answer-form" data-key={answer.id} />
+  ),
+}));
+vi.mock("@/layouts/BaseLayout", () => ({
+  __esModule: true,
+  default: ({
+    children,
+    title,
+  }: {
+    children: React.ReactNode;
+    title: string;
+  }) => (
+    <div data-testid="base-layout" data-title={title}>
+      {children}
+    </div>
   ),
 }));
 
@@ -74,7 +86,8 @@ describe("ScoringProblem", () => {
     );
 
     // then
-    expect(screen.queryByTestId("navbar")).not.toBeInTheDocument();
+    // baselayout が表示される
+    expect(screen.queryByTestId("base-layout")).not.toBeInTheDocument();
     expect(useAuth).toHaveBeenCalledTimes(1);
     expect(useProblem).toHaveBeenCalledTimes(1);
     expect(useAnswers).toHaveBeenCalledTimes(1);
@@ -102,7 +115,7 @@ describe("ScoringProblem", () => {
     );
 
     // then
-    expect(screen.queryByTestId("navbar")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("base-layout")).not.toBeInTheDocument();
     expect(useAuth).toHaveBeenCalledTimes(1);
     expect(useProblem).toHaveBeenCalledTimes(1);
     expect(useAnswers).toHaveBeenCalledTimes(1);
@@ -130,7 +143,7 @@ describe("ScoringProblem", () => {
     );
 
     // then
-    expect(screen.queryByTestId("navbar")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("base-layout")).not.toBeInTheDocument();
     expect(useAuth).toHaveBeenCalledTimes(1);
     expect(useProblem).toHaveBeenCalledTimes(1);
     expect(useAnswers).toHaveBeenCalledTimes(1);
@@ -158,7 +171,7 @@ describe("ScoringProblem", () => {
     );
 
     // then
-    expect(screen.queryByTestId("navbar")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("base-layout")).not.toBeInTheDocument();
     expect(useAuth).toHaveBeenCalledTimes(1);
     expect(useProblem).toHaveBeenCalledTimes(1);
     expect(useAnswers).toHaveBeenCalledTimes(1);
@@ -186,7 +199,11 @@ describe("ScoringProblem", () => {
     expect(screen.queryByTestId("loading")).toBeInTheDocument();
 
     // then
-    expect(screen.queryByTestId("navbar")).toBeInTheDocument();
+    expect(screen.queryByTestId("base-layout")).toBeInTheDocument();
+    expect(screen.queryByTestId("base-layout")).toHaveAttribute(
+      "data-title",
+      "採点"
+    );
     expect(useAuth).toHaveBeenCalledTimes(1);
     expect(useProblem).toHaveBeenCalledTimes(1);
     expect(useAnswers).toHaveBeenCalledTimes(1);

--- a/frontend/octavio/__test__/pages/scoring/index.test.tsx
+++ b/frontend/octavio/__test__/pages/scoring/index.test.tsx
@@ -1,5 +1,7 @@
 import "@testing-library/jest-dom";
 
+import React from "react";
+
 import { act, render, screen } from "@testing-library/react";
 import { Mock, vi } from "vitest";
 
@@ -18,13 +20,23 @@ vi.mock("next/error", () => ({
 vi.mock("next/router", () => require("next-router-mock"));
 vi.mock("@/hooks/auth");
 vi.mock("@/hooks/problems");
-vi.mock("@/components/Navbar", () => ({
-  __esModule: true,
-  default: () => <div data-testid="navbar" />,
-}));
 vi.mock("@/components/LoadingPage", () => ({
   __esModule: true,
   default: () => <div data-testid="loading" />,
+}));
+vi.mock("@/layouts/BaseLayout", () => ({
+  __esModule: true,
+  default: ({
+    children,
+    title,
+  }: {
+    children: React.ReactNode;
+    title: string;
+  }) => (
+    <div data-testid="base-layout" data-title={title}>
+      {children}
+    </div>
+  ),
 }));
 
 beforeEach(() => {
@@ -52,7 +64,7 @@ describe("Scoring", () => {
     );
 
     // then
-    expect(screen.queryByTestId("navbar")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("base-layout")).not.toBeInTheDocument();
     expect(useAuth).toHaveBeenCalledTimes(1);
     expect(useProblems).toHaveBeenCalledTimes(2);
   });
@@ -76,7 +88,7 @@ describe("Scoring", () => {
     );
 
     // then
-    expect(screen.queryByTestId("navbar")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("base-layout")).not.toBeInTheDocument();
     expect(useAuth).toHaveBeenCalledTimes(1);
     expect(useProblems).toHaveBeenCalledTimes(2);
   });
@@ -100,7 +112,7 @@ describe("Scoring", () => {
     );
 
     // then
-    expect(screen.queryByTestId("navbar")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("base-layout")).not.toBeInTheDocument();
     expect(useAuth).toHaveBeenCalledTimes(1);
     expect(useProblems).toHaveBeenCalledTimes(2);
   });
@@ -117,10 +129,15 @@ describe("Scoring", () => {
     render(<Index />);
 
     // when
+    expect(screen.queryByTestId("base-layout")).toBeInTheDocument();
+    expect(screen.queryByTestId("base-layout")).toHaveAttribute(
+      "data-title",
+      "採点"
+    );
     expect(screen.queryByTestId("loading")).toBeInTheDocument();
 
     // then
-    expect(screen.queryByTestId("navbar")).toBeInTheDocument();
+    expect(screen.queryByTestId("base-layout")).toBeInTheDocument();
     expect(useAuth).toHaveBeenCalledTimes(1);
     expect(useProblems).toHaveBeenCalledTimes(2);
   });
@@ -138,6 +155,11 @@ describe("Scoring", () => {
     const tds = screen.queryAllByRole("cell");
 
     // when
+    expect(screen.queryByTestId("base-layout")).toBeInTheDocument();
+    expect(screen.queryByTestId("base-layout")).toHaveAttribute(
+      "data-title",
+      "採点"
+    );
     expect(screen.queryByText("採点")).toBeInTheDocument();
     expect(tds[1]).toHaveTextContent("/-/-");
     expect(tds[2]).toHaveTextContent("id");
@@ -150,7 +172,7 @@ describe("Scoring", () => {
     expect(tds[9]).toHaveTextContent("自分");
 
     // then
-    expect(screen.queryByTestId("navbar")).toBeInTheDocument();
+    expect(screen.queryByTestId("base-layout")).toBeInTheDocument();
     expect(useAuth).toHaveBeenCalledTimes(1);
     expect(useProblems).toHaveBeenCalledTimes(2);
   });
@@ -171,7 +193,7 @@ describe("Scoring", () => {
     expect(tds[1]).toHaveTextContent("1/-/-");
 
     // then
-    expect(screen.queryByTestId("navbar")).toBeInTheDocument();
+    expect(screen.queryByTestId("base-layout")).toBeInTheDocument();
     expect(useAuth).toHaveBeenCalledTimes(1);
     expect(useProblems).toHaveBeenCalledTimes(2);
   });
@@ -192,7 +214,7 @@ describe("Scoring", () => {
     expect(tds[1]).toHaveTextContent("/1/-");
 
     // then
-    expect(screen.queryByTestId("navbar")).toBeInTheDocument();
+    expect(screen.queryByTestId("base-layout")).toBeInTheDocument();
     expect(useAuth).toHaveBeenCalledTimes(1);
     expect(useProblems).toHaveBeenCalledTimes(2);
   });
@@ -213,7 +235,7 @@ describe("Scoring", () => {
     expect(tds[1]).toHaveTextContent("/-/1");
 
     // then
-    expect(screen.queryByTestId("navbar")).toBeInTheDocument();
+    expect(screen.queryByTestId("base-layout")).toBeInTheDocument();
     expect(useAuth).toHaveBeenCalledTimes(1);
     expect(useProblems).toHaveBeenCalledTimes(2);
   });
@@ -251,7 +273,7 @@ describe("Scoring", () => {
     expect(tds[5]).toHaveTextContent(`${"a".repeat(20)}...`);
 
     // then
-    expect(screen.queryByTestId("navbar")).toBeInTheDocument();
+    expect(screen.queryByTestId("base-layout")).toBeInTheDocument();
     expect(useAuth).toHaveBeenCalledTimes(1);
     expect(useProblems).toHaveBeenCalledTimes(2);
   });
@@ -273,7 +295,7 @@ describe("Scoring", () => {
     expect(tds[5]).toHaveTextContent("");
 
     // then
-    expect(screen.queryByTestId("navbar")).toBeInTheDocument();
+    expect(screen.queryByTestId("base-layout")).toBeInTheDocument();
     expect(useAuth).toHaveBeenCalledTimes(1);
     expect(useProblems).toHaveBeenCalledTimes(2);
   });
@@ -294,7 +316,7 @@ describe("Scoring", () => {
     expect(tds[9]).toHaveTextContent("");
 
     // then
-    expect(screen.queryByTestId("navbar")).toBeInTheDocument();
+    expect(screen.queryByTestId("base-layout")).toBeInTheDocument();
     expect(useAuth).toHaveBeenCalledTimes(1);
     expect(useProblems).toHaveBeenCalledTimes(2);
   });
@@ -317,7 +339,7 @@ describe("Scoring", () => {
     expect(screen.queryByText("採点する")).toBeInTheDocument();
 
     // then
-    expect(screen.queryByTestId("navbar")).toBeInTheDocument();
+    expect(screen.queryByTestId("base-layout")).toBeInTheDocument();
     expect(useAuth).toHaveBeenCalledTimes(2);
     expect(useProblems).toHaveBeenCalledTimes(4);
   });

--- a/frontend/octavio/__test__/pages/signUp.test.tsx
+++ b/frontend/octavio/__test__/pages/signUp.test.tsx
@@ -39,6 +39,20 @@ vi.mock("@/components/Alerts", () => ({
     />
   ),
 }));
+vi.mock("@/layouts/BaseLayout", () => ({
+  __esModule: true,
+  default: ({
+    children,
+    title,
+  }: {
+    children: React.ReactNode;
+    title: string;
+  }) => (
+    <div data-testid="base-layout" data-title={title}>
+      {children}
+    </div>
+  ),
+}));
 
 beforeEach(() => {
   // toHaveBeenCalledTimes がテストごとにリセットされるようにする
@@ -56,13 +70,18 @@ describe("SignUp", () => {
     render(<SignUp />);
 
     // then
+    expect(screen.getByTestId("base-layout")).toBeInTheDocument();
+    expect(screen.getByTestId("base-layout")).toHaveAttribute(
+      "data-title",
+      "ユーザー登録"
+    );
     expect(screen.queryByPlaceholderText("ユーザー名")).toBeInTheDocument();
     expect(screen.queryByPlaceholderText("パスワード")).toBeInTheDocument();
     expect(screen.queryByRole("button")).toBeInTheDocument();
     expect(screen.queryByRole("button")).not.toHaveAttribute("loading");
 
     // verify
-    expect(useAuth).toHaveBeenCalledTimes(2);
+    expect(useAuth).toHaveBeenCalledTimes(1);
   });
 
   test("未入力で送信した時にエラーメッセージが表示されることを確認する", async () => {
@@ -86,7 +105,7 @@ describe("SignUp", () => {
     ).toBeInTheDocument();
 
     // verify
-    expect(useAuth).toHaveBeenCalledTimes(4);
+    expect(useAuth).toHaveBeenCalledTimes(2);
   });
 
   test("ユーザー名が未入力で送信した時にエラーメッセージが表示されることを確認する", async () => {
@@ -112,7 +131,7 @@ describe("SignUp", () => {
     ).not.toBeInTheDocument();
 
     // verify
-    expect(useAuth).toHaveBeenCalledTimes(4);
+    expect(useAuth).toHaveBeenCalledTimes(2);
   });
 
   test("パスワード名が未入力で送信した時にエラーメッセージが表示されることを確認する", async () => {
@@ -138,7 +157,7 @@ describe("SignUp", () => {
     ).toBeInTheDocument();
 
     // verify
-    expect(useAuth).toHaveBeenCalledTimes(4);
+    expect(useAuth).toHaveBeenCalledTimes(2);
   });
 
   test("パスワードが8文字未満で入力した場合にエラーが表示される", async () => {
@@ -162,7 +181,7 @@ describe("SignUp", () => {
     ).toBeInTheDocument();
 
     // verify
-    expect(useAuth).toHaveBeenCalledTimes(4);
+    expect(useAuth).toHaveBeenCalledTimes(2);
   });
 
   test("登録が成功した場合にホーム画面に遷移することを確認する", async () => {
@@ -195,7 +214,7 @@ describe("SignUp", () => {
     expect(alert).not.toHaveAttribute("data-sub-message");
 
     // verify
-    expect(useAuth).toHaveBeenCalledTimes(4);
+    expect(useAuth).toHaveBeenCalledTimes(2);
     expect(signUp).toHaveBeenCalledTimes(1);
   });
 
@@ -231,7 +250,7 @@ describe("SignUp", () => {
     );
 
     // verify
-    expect(useAuth).toHaveBeenCalledTimes(4);
+    expect(useAuth).toHaveBeenCalledTimes(2);
   });
 
   test("UserGroupID が無効な場合にエラーが表示されることを確認する", async () => {
@@ -266,7 +285,7 @@ describe("SignUp", () => {
     );
 
     // verify
-    expect(useAuth).toHaveBeenCalledTimes(4);
+    expect(useAuth).toHaveBeenCalledTimes(2);
   });
 
   test("UserGroupID の uuid 形式が無効な場合にエラーが表示されることを確認する", async () => {
@@ -301,7 +320,7 @@ describe("SignUp", () => {
     );
 
     // verify
-    expect(useAuth).toHaveBeenCalledTimes(4);
+    expect(useAuth).toHaveBeenCalledTimes(2);
   });
 
   test("InvitationCode が無効の場合", async () => {
@@ -333,7 +352,7 @@ describe("SignUp", () => {
     expect(alert).toHaveAttribute("data-sub-message", "無効な招待コードです。");
 
     // verify
-    expect(useAuth).toHaveBeenCalledTimes(4);
+    expect(useAuth).toHaveBeenCalledTimes(2);
   });
 
   test("不明のエラーの場合にエラーが表示されることを確認する", async () => {
@@ -365,7 +384,7 @@ describe("SignUp", () => {
     expect(alert).toHaveAttribute("data-sub-message", "");
 
     // verify
-    expect(useAuth).toHaveBeenCalledTimes(4);
+    expect(useAuth).toHaveBeenCalledTimes(2);
   });
 
   test("フォームが送信中の場合にボタンが無効になることを確認する", async () => {
@@ -397,7 +416,7 @@ describe("SignUp", () => {
     expect(button).toHaveClass("loading");
 
     // verify
-    expect(useAuth).toHaveBeenCalledTimes(4);
+    expect(useAuth).toHaveBeenCalledTimes(2);
     expect(signUp).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/octavio/__test__/pages/signUp.test.tsx
+++ b/frontend/octavio/__test__/pages/signUp.test.tsx
@@ -55,11 +55,14 @@ describe("SignUp", () => {
     });
     render(<SignUp />);
 
-    // verify
+    // then
     expect(screen.queryByPlaceholderText("ユーザー名")).toBeInTheDocument();
     expect(screen.queryByPlaceholderText("パスワード")).toBeInTheDocument();
     expect(screen.queryByRole("button")).toBeInTheDocument();
     expect(screen.queryByRole("button")).not.toHaveAttribute("loading");
+
+    // verify
+    expect(useAuth).toHaveBeenCalledTimes(2);
   });
 
   test("未入力で送信した時にエラーメッセージが表示されることを確認する", async () => {
@@ -81,6 +84,9 @@ describe("SignUp", () => {
     expect(
       screen.queryByText("パスワードを入力して下さい")
     ).toBeInTheDocument();
+
+    // verify
+    expect(useAuth).toHaveBeenCalledTimes(4);
   });
 
   test("ユーザー名が未入力で送信した時にエラーメッセージが表示されることを確認する", async () => {
@@ -104,6 +110,9 @@ describe("SignUp", () => {
     expect(
       screen.queryByText("パスワードを入力して下さい")
     ).not.toBeInTheDocument();
+
+    // verify
+    expect(useAuth).toHaveBeenCalledTimes(4);
   });
 
   test("パスワード名が未入力で送信した時にエラーメッセージが表示されることを確認する", async () => {
@@ -127,6 +136,9 @@ describe("SignUp", () => {
     expect(
       screen.queryByText("パスワードを入力して下さい")
     ).toBeInTheDocument();
+
+    // verify
+    expect(useAuth).toHaveBeenCalledTimes(4);
   });
 
   test("パスワードが8文字未満で入力した場合にエラーが表示される", async () => {
@@ -148,6 +160,9 @@ describe("SignUp", () => {
     expect(
       screen.queryByText("パスワードは8文字以上である必要があります")
     ).toBeInTheDocument();
+
+    // verify
+    expect(useAuth).toHaveBeenCalledTimes(4);
   });
 
   test("登録が成功した場合にホーム画面に遷移することを確認する", async () => {
@@ -214,6 +229,9 @@ describe("SignUp", () => {
       "data-sub-message",
       "ユーザー名が重複しています。"
     );
+
+    // verify
+    expect(useAuth).toHaveBeenCalledTimes(4);
   });
 
   test("UserGroupID が無効な場合にエラーが表示されることを確認する", async () => {
@@ -246,6 +264,9 @@ describe("SignUp", () => {
       "data-sub-message",
       "無効なユーザーグループです。"
     );
+
+    // verify
+    expect(useAuth).toHaveBeenCalledTimes(4);
   });
 
   test("UserGroupID の uuid 形式が無効な場合にエラーが表示されることを確認する", async () => {
@@ -278,6 +299,9 @@ describe("SignUp", () => {
       "data-sub-message",
       "無効なユーザーグループです。"
     );
+
+    // verify
+    expect(useAuth).toHaveBeenCalledTimes(4);
   });
 
   test("InvitationCode が無効の場合", async () => {
@@ -307,6 +331,9 @@ describe("SignUp", () => {
     expect(alert).toBeInTheDocument();
     expect(alert).toHaveAttribute("data-message", "エラーが発生しました");
     expect(alert).toHaveAttribute("data-sub-message", "無効な招待コードです。");
+
+    // verify
+    expect(useAuth).toHaveBeenCalledTimes(4);
   });
 
   test("不明のエラーの場合にエラーが表示されることを確認する", async () => {
@@ -336,6 +363,9 @@ describe("SignUp", () => {
     expect(alert).toBeInTheDocument();
     expect(alert).toHaveAttribute("data-message", "エラーが発生しました");
     expect(alert).toHaveAttribute("data-sub-message", "");
+
+    // verify
+    expect(useAuth).toHaveBeenCalledTimes(4);
   });
 
   test("フォームが送信中の場合にボタンが無効になることを確認する", async () => {

--- a/frontend/octavio/__test__/pages/team_info.test.tsx
+++ b/frontend/octavio/__test__/pages/team_info.test.tsx
@@ -15,10 +15,6 @@ import { testUserGroup } from "@/types/UserGroup";
 vi.mock("react");
 vi.mock("@/hooks/auth");
 vi.mock("@/hooks/ranking");
-vi.mock("@/components/Navbar", () => ({
-  __esModule: true,
-  default: () => <div data-testid="navbar" />,
-}));
 
 vi.mock("@/components/HiddenInput", () => ({
   __esModule: true,
@@ -51,6 +47,20 @@ vi.mock("@/components/icons/EyeSlash", () => ({
   __esModule: true,
   default: () => <div data-testid="eye-slash" />,
 }));
+vi.mock("@/layouts/CommonLayout", () => ({
+  __esModule: true,
+  default: ({
+    children,
+    title,
+  }: {
+    children: React.ReactNode;
+    title: string;
+  }) => (
+    <div data-testid="common-layout" data-title={title}>
+      {children}
+    </div>
+  ),
+}));
 
 beforeEach(() => {
   // toHaveBeenCalledTimes がテストごとにリセットされるようにする
@@ -76,7 +86,11 @@ describe("TeamInfo", () => {
     render(<TeamInfo />);
 
     // then
-    expect(screen.getByTestId("navbar")).toBeInTheDocument();
+    expect(screen.getByTestId("common-layout")).toBeInTheDocument();
+    expect(screen.getByTestId("common-layout")).toHaveAttribute(
+      "data-title",
+      "チーム情報"
+    );
     expect(
       screen.getByText(`${testUserGroup.name}@${testUserGroup.organization}`)
     ).toBeInTheDocument();
@@ -116,7 +130,7 @@ describe("TeamInfo", () => {
     render(<TeamInfo />);
 
     // then
-    expect(screen.getByTestId("navbar")).toBeInTheDocument();
+    expect(screen.getByTestId("common-layout")).toBeInTheDocument();
     expect(screen.getByTestId("loading")).toBeInTheDocument();
 
     // verify
@@ -143,7 +157,7 @@ describe("TeamInfo", () => {
     render(<TeamInfo />);
 
     // then
-    expect(screen.getByTestId("navbar")).toBeInTheDocument();
+    expect(screen.getByTestId("common-layout")).toBeInTheDocument();
     expect(screen.getByTestId("loading")).toBeInTheDocument();
 
     // verify
@@ -170,7 +184,7 @@ describe("TeamInfo", () => {
     render(<TeamInfo />);
 
     // then
-    expect(screen.getByTestId("navbar")).toBeInTheDocument();
+    expect(screen.getByTestId("common-layout")).toBeInTheDocument();
     expect(screen.getByTestId("loading")).toBeInTheDocument();
 
     // verify
@@ -196,7 +210,7 @@ describe("TeamInfo", () => {
     render(<TeamInfo />);
 
     // then
-    expect(screen.getByTestId("navbar")).toBeInTheDocument();
+    expect(screen.getByTestId("common-layout")).toBeInTheDocument();
     const hiddenInputs = screen.getAllByTestId("hidden-input");
     expect(hiddenInputs[0]).toHaveAttribute("data-value", "ssh @ -p ");
     expect(hiddenInputs[1]).toHaveAttribute("data-value", "");
@@ -231,7 +245,7 @@ describe("TeamInfo", () => {
     render(<TeamInfo />);
 
     // then
-    expect(screen.getByTestId("navbar")).toBeInTheDocument();
+    expect(screen.getByTestId("common-layout")).toBeInTheDocument();
     const hiddenInputs = screen.getAllByTestId("hidden-input");
     expect(hiddenInputs[0]).toHaveAttribute(
       "data-value",
@@ -272,7 +286,7 @@ describe("TeamInfo", () => {
     render(<TeamInfo />);
 
     // then
-    expect(screen.getByTestId("navbar")).toBeInTheDocument();
+    expect(screen.getByTestId("common-layout")).toBeInTheDocument();
     const hiddenInputs = screen.getAllByTestId("hidden-input");
     expect(hiddenInputs[0]).toHaveAttribute(
       "data-value",
@@ -313,7 +327,7 @@ describe("TeamInfo", () => {
     render(<TeamInfo />);
 
     // then
-    expect(screen.getByTestId("navbar")).toBeInTheDocument();
+    expect(screen.getByTestId("common-layout")).toBeInTheDocument();
     const hiddenInputs = screen.getAllByTestId("hidden-input");
     expect(hiddenInputs[0]).toHaveAttribute(
       "data-value",
@@ -352,10 +366,8 @@ describe("TeamInfo", () => {
     // when
     render(<TeamInfo />);
 
-    screen.debug();
-
     // then
-    expect(screen.getByTestId("navbar")).toBeInTheDocument();
+    expect(screen.getByTestId("common-layout")).toBeInTheDocument();
     const hiddenInputs = screen.getAllByTestId("hidden-input");
     expect(hiddenInputs[0]).toHaveAttribute(
       "data-value",
@@ -387,7 +399,7 @@ describe("TeamInfo", () => {
     render(<TeamInfo />);
 
     // then
-    expect(screen.getByTestId("navbar")).toBeInTheDocument();
+    expect(screen.getByTestId("common-layout")).toBeInTheDocument();
     const hiddenInputs = screen.getAllByTestId("hidden-input");
     expect(hiddenInputs[0]).toHaveAttribute("data-is-hidden", "true");
     expect(screen.queryAllByTestId("eye")).toHaveLength(2);
@@ -417,7 +429,7 @@ describe("TeamInfo", () => {
     render(<TeamInfo />);
 
     // then
-    expect(screen.getByTestId("navbar")).toBeInTheDocument();
+    expect(screen.getByTestId("common-layout")).toBeInTheDocument();
     const hiddenInputs = screen.getAllByTestId("hidden-input");
     expect(hiddenInputs[0]).toHaveAttribute("data-is-hidden", "false");
     expect(screen.queryAllByTestId("eye")).toHaveLength(1);
@@ -447,7 +459,7 @@ describe("TeamInfo", () => {
     render(<TeamInfo />);
 
     // then
-    expect(screen.getByTestId("navbar")).toBeInTheDocument();
+    expect(screen.getByTestId("common-layout")).toBeInTheDocument();
     const hiddenInputs = screen.getAllByTestId("hidden-input");
     expect(hiddenInputs[1]).toHaveAttribute("data-is-hidden", "true");
     expect(screen.queryAllByTestId("eye")).toHaveLength(1);
@@ -477,7 +489,7 @@ describe("TeamInfo", () => {
     render(<TeamInfo />);
 
     // then
-    expect(screen.getByTestId("navbar")).toBeInTheDocument();
+    expect(screen.getByTestId("common-layout")).toBeInTheDocument();
     const hiddenInputs = screen.getAllByTestId("hidden-input");
     expect(hiddenInputs[1]).toHaveAttribute("data-is-hidden", "false");
     expect(screen.queryAllByTestId("eye")).toHaveLength(0);

--- a/frontend/octavio/__test__/pages/users.test.tsx
+++ b/frontend/octavio/__test__/pages/users.test.tsx
@@ -1,4 +1,6 @@
 import "@testing-library/jest-dom";
+import React from "react";
+
 import { render, screen } from "@testing-library/react";
 import { Mock, vi } from "vitest";
 
@@ -14,13 +16,23 @@ vi.mock("next/error", () => ({
   ),
 }));
 vi.mock("@/hooks/userGroups");
-vi.mock("@/components/Navbar", () => ({
-  __esModule: true,
-  default: () => <div data-testid="navbar" />,
-}));
 vi.mock("@/components/LoadingPage", () => ({
   __esModule: true,
   default: () => <div data-testid="loading" />,
+}));
+vi.mock("@/layouts/CommonLayout", () => ({
+  __esModule: true,
+  default: ({
+    children,
+    title,
+  }: {
+    children: React.ReactNode;
+    title: string;
+  }) => (
+    <div data-testid="common-layout" data-title={title}>
+      {children}
+    </div>
+  ),
 }));
 
 beforeEach(() => {
@@ -40,7 +52,11 @@ describe("Users", () => {
     render(<Users />);
 
     // then
-    expect(screen.getByTestId("navbar")).toBeInTheDocument();
+    expect(screen.getByTestId("common-layout")).toBeInTheDocument();
+    expect(screen.getByTestId("common-layout")).toHaveAttribute(
+      "data-title",
+      "参加者一覧"
+    );
     const cells = screen.getAllByRole("cell");
     expect(cells[0]).toHaveTextContent(testUser.display_name);
     expect(cells[1]).toHaveTextContent(testUserGroup.name);
@@ -74,7 +90,7 @@ describe("Users", () => {
     render(<Users />);
 
     // then
-    expect(screen.getByTestId("navbar")).toBeInTheDocument();
+    expect(screen.getByTestId("common-layout")).toBeInTheDocument();
     expect(screen.getByTestId("loading")).toBeInTheDocument();
 
     // verify
@@ -113,7 +129,7 @@ describe("Users", () => {
     render(<Users />);
 
     // then
-    expect(screen.getByTestId("navbar")).toBeInTheDocument();
+    expect(screen.getByTestId("common-layout")).toBeInTheDocument();
     expect(screen.queryByRole("cell")).toBeNull();
 
     // verify
@@ -131,7 +147,7 @@ describe("Users", () => {
     render(<Users />);
 
     // then
-    expect(screen.getByTestId("navbar")).toBeInTheDocument();
+    expect(screen.getByTestId("common-layout")).toBeInTheDocument();
     expect(screen.queryByRole("cell")).toBeNull();
   });
 
@@ -150,7 +166,7 @@ describe("Users", () => {
     render(<Users />);
 
     // then
-    expect(screen.getByTestId("navbar")).toBeInTheDocument();
+    expect(screen.getByTestId("common-layout")).toBeInTheDocument();
     const links = screen.getAllByRole("link");
     expect(links[0]).toHaveAttribute(
       "href",
@@ -180,7 +196,7 @@ describe("Users", () => {
     render(<Users />);
 
     // then
-    expect(screen.getByTestId("navbar")).toBeInTheDocument();
+    expect(screen.getByTestId("common-layout")).toBeInTheDocument();
     const links = screen.getAllByRole("link");
     expect(links[0]).toHaveAttribute(
       "href",
@@ -206,7 +222,7 @@ describe("Users", () => {
     render(<Users />);
 
     // then
-    expect(screen.getByTestId("navbar")).toBeInTheDocument();
+    expect(screen.getByTestId("common-layout")).toBeInTheDocument();
     const links = screen.getAllByRole("link");
     expect(links[0]).toHaveAttribute(
       "href",
@@ -233,7 +249,7 @@ describe("Users", () => {
     render(<Users />);
 
     // then
-    expect(screen.getByTestId("navbar")).toBeInTheDocument();
+    expect(screen.getByTestId("common-layout")).toBeInTheDocument();
     expect(screen.queryByRole("link")).not.toBeInTheDocument();
   });
 });

--- a/frontend/octavio/components/MarkdownPreview.tsx
+++ b/frontend/octavio/components/MarkdownPreview.tsx
@@ -21,7 +21,7 @@ const CopyOutlineIcon = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24
       </g>
     </svg>`;
 
-function MarkdownPreview({ className, content }: Props) {
+function MarkdownPreview({ className, content = "" }: Props) {
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {

--- a/frontend/octavio/components/NotificationCard.tsx
+++ b/frontend/octavio/components/NotificationCard.tsx
@@ -29,7 +29,7 @@ function NotificationCard({ notice, onDismiss }: Props) {
                 </button>
               )}
             </div>
-            <MarkdownPreview content={notice.body ?? ""} />
+            <MarkdownPreview content={notice.body} />
           </div>
         </div>
       </div>

--- a/frontend/octavio/pages/problems/[problemId].tsx
+++ b/frontend/octavio/pages/problems/[problemId].tsx
@@ -133,7 +133,7 @@ function ProblemPage() {
               </div>
             )}
           <ICTSCCard className="mt-8">
-            <MarkdownPreview content={problem.body ?? ""} />
+            <MarkdownPreview content={problem.body} />
           </ICTSCCard>
 
           {!isReadOnly && <AnswerForm />}

--- a/frontend/octavio/pages/scoring/[code].tsx
+++ b/frontend/octavio/pages/scoring/[code].tsx
@@ -58,7 +58,7 @@ function ScoringProblem() {
           <ProblemMeta problem={problem} />
         </div>
         <ICTSCCard className="ml-0">
-          <MarkdownPreview content={problem.body ?? ""} />
+          <MarkdownPreview content={problem.body} />
         </ICTSCCard>
         <div className="divider" />
         <ProblemConnectionInfo matter={matter} />

--- a/frontend/octavio/pages/scoring/index.tsx
+++ b/frontend/octavio/pages/scoring/index.tsx
@@ -124,7 +124,7 @@ function Index() {
             </Link>
           </div>
           <ICTSCCard>
-            <MarkdownPreview content={problem.body ?? ""} />
+            <MarkdownPreview content={problem.body} />
           </ICTSCCard>
         </div>
       )}


### PR DESCRIPTION
## 主な変更

* refactor: common-layout, base-layout をモックするように変更
* refactor: MarkdownPreview の content にデフォルト引数を追加