### PR TITLE
use 'npm' for yaml value

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "pnpm" # See documentation for possible values
+  - package-ecosystem: "npm" # See documentation for possible values
     directory: "/frontend/octavio" # Location of package manifests
     schedule:
       interval: "weekly"


### PR DESCRIPTION
pnpmだとdependabotが動かないため修正