### PR TITLE
Redis Clientにサービス名を登録するように

### DIFF
--- a/backend/pkg/db/redis/operations.go
+++ b/backend/pkg/db/redis/operations.go
@@ -10,7 +10,7 @@ import (
 
 // Get 指定したキーの値を取得する
 func (r *Redis[V]) Get(ctx context.Context, key string) (*V, error) { // nolint:ireturn
-	valueStr, err := r.c.Get(ctx, key).Result()
+	valueStr, err := r.c.Get(ctx, r.srv+key).Result()
 	if err != nil {
 		return nil, errors.Wrap(err)
 	}
@@ -30,7 +30,7 @@ func (r *Redis[V]) Set(ctx context.Context, key string, value V, ttl int) error 
 		return errors.Wrap(err)
 	}
 
-	err = r.c.Set(ctx, key, string(valueStr), time.Millisecond*time.Duration(ttl)).Err()
+	err = r.c.Set(ctx, r.srv+key, string(valueStr), time.Millisecond*time.Duration(ttl)).Err()
 
 	return errors.Wrap(err)
 }

--- a/backend/pkg/db/redis/operations.go
+++ b/backend/pkg/db/redis/operations.go
@@ -10,7 +10,7 @@ import (
 
 // Get 指定したキーの値を取得する
 func (r *Redis[V]) Get(ctx context.Context, key string) (*V, error) { // nolint:ireturn
-	valueStr, err := r.c.Get(ctx, r.srv+key).Result()
+	valueStr, err := r.c.Get(ctx, r.srv+"-"+key).Result()
 	if err != nil {
 		return nil, errors.Wrap(err)
 	}
@@ -30,7 +30,7 @@ func (r *Redis[V]) Set(ctx context.Context, key string, value V, ttl int) error 
 		return errors.Wrap(err)
 	}
 
-	err = r.c.Set(ctx, r.srv+key, string(valueStr), time.Millisecond*time.Duration(ttl)).Err()
+	err = r.c.Set(ctx, r.srv+"-"+key, string(valueStr), time.Millisecond*time.Duration(ttl)).Err()
 
 	return errors.Wrap(err)
 }

--- a/backend/pkg/db/redis/redis.go
+++ b/backend/pkg/db/redis/redis.go
@@ -14,11 +14,14 @@ type Config struct {
 	Username string
 	Password string
 	Database int
+
+	Service string // Redisを利用しているサービス名
 }
 
 // Redis Redisクライアント
 type Redis[V any] struct {
-	c *redis.Client
+	c   *redis.Client
+	srv string
 }
 
 // New Redisクライアント生成
@@ -30,5 +33,6 @@ func New[V any](conf *Config) *Redis[V] {
 			Password: conf.Password,
 			DB:       conf.Database,
 		}),
+		srv: conf.Service,
 	}
 }


### PR DESCRIPTION
少ないDB数でユニークキーを生成するため、自由なスキーマでデータを入れられる利点を生かし、キーの前にサービス名を付けることで唯一性を担保するようになった
これで、極論すべてのサービスで同じDBを使うことも可能