### PR TITLE
Fix broken link in `init.sh`

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -2,7 +2,7 @@
 
 if ! (type task >/dev/null 2>&1); then
   echo "下記公式ドキュメントを参考に、taskをインストールした後、もう一度init.shを実行してください"
-  echo "https://taskfile.dev/ja-JP/installation/"
+  echo "https://taskfile.dev/installation/"
 fi
 
 task init


### PR DESCRIPTION
# 概要

`init.sh` で task コマンドが呼び出せないときに表示されるインストール用ページのリンクが切れているため、修正します。